### PR TITLE
Improve EXP.SHARE experience gained message

### DIFF
--- a/engine/battle/15.asm
+++ b/engine/battle/15.asm
@@ -21,6 +21,16 @@ GainExperience: ; 5524f (15:524f)
 	and a ; is mon's gain exp flag set?
 	pop hl
 	jp z, .nextMon ; if mon's gain exp flag not set, go to next mon
+	ld a, [wcc5b]
+	and a
+	jp z, .finishedExpAllMessage
+	xor a
+	ld [wcc5b], a
+	push hl
+	ld hl, WithExpAllText
+	call PrintText
+	pop hl
+.finishedExpAllMessage 
 	ld de, (wPartyMon1HPExp + 1) - (wPartyMon1HP + 1)
 	add hl, de
 	ld d, h
@@ -369,10 +379,6 @@ BoostExp: ; 5549f (15:549f)
 GainedText: ; 554b2 (15:54b2)
 	TX_FAR _GainedText
 	db $08 ; asm
-	ld a, [wcc5b]
-	ld hl, WithExpAllText
-	and a
-	ret nz
 	ld hl, ExpPointsText
 	ld a, [wcf4d]
 	and a
@@ -382,9 +388,7 @@ GainedText: ; 554b2 (15:54b2)
 
 WithExpAllText: ; 554cb (15:54cb)
 	TX_FAR _WithExpAllText
-	db $08 ; asm
-	ld hl, ExpPointsText
-	ret
+	db "@"
 
 BoostedText: ; 554d4 (15:54d4)
 	TX_FAR _BoostedText

--- a/engine/battle/core.asm
+++ b/engine/battle/core.asm
@@ -944,15 +944,25 @@ FaintEnemyPokemon ; 0x3c567
 	call SaveScreenTilesToBuffer1
 	xor a
 	ld [wBattleResult], a
+
+    ; give EXP to mons that fought
+	ld [wcc5b], a
+    ld a, [wPartyGainExpFlags]
+    push af
+	callab GainExperience
+
 	ld b, EXP_SHARE
 	call IsItemInBag
-	push af
-	jr z, .giveExpToMonsThatFought ; if no exp all, then jump
+    pop bc
+	ret z
 
-; the player has exp all
-; first, we halve the values that determine exp gain
-; the enemy mon base stats are added to stat exp, so they are halved
-; the base exp (which determines normal exp) is also halved
+	; handle EXP all
+    push bc
+    ld a, $1
+	ld [wcc5b], a
+	; first, we halve the values that determine exp gain
+    ; the enemy mon base stats are added to stat exp, so they are halved
+    ; the base exp (which determines normal exp) is also halved
 	ld hl, wEnemyMonBaseStats
 	ld b, $7
 .halveExpDataLoop
@@ -961,20 +971,8 @@ FaintEnemyPokemon ; 0x3c567
 	dec b
 	jr nz, .halveExpDataLoop
 
-; give exp (divided evenly) to the mons that actually fought in battle against the enemy mon that has fainted
-; if exp all is in the bag, this will be only be half of the stat exp and normal exp, due to the above loop
-.giveExpToMonsThatFought
-	xor a
-	ld [wcc5b], a
-	callab GainExperience
-	pop af
-	ret z ; return if no exp all
-
-; the player has exp all
-; now, set the gain exp flag for every party member
-; half of the total stat exp and normal exp will divided evenly amongst every party member
-	ld a, $1
-	ld [wcc5b], a
+	; find mons that did NOT fight in the battle
+		; b = 00111111 (ones count = # mons in party)
 	ld a, [wPartyCount]
 	ld b, 0
 .gainExpFlagsLoop
@@ -982,8 +980,14 @@ FaintEnemyPokemon ; 0x3c567
 	rl b
 	dec a
 	jr nz, .gainExpFlagsLoop
-	ld a, b
+
+		; a = party gain flags
+	pop af
+	
+		; a = a XOR b = flags for mons that didn't fight
+	xor b
 	ld [wPartyGainExpFlags], a
+	
 	ld hl, GainExperience
 	ld b, BANK(GainExperience)
 	jp Bankswitch

--- a/text.asm
+++ b/text.asm
@@ -1384,8 +1384,12 @@ _GainedText:: ; 89bc2 (22:5bc2)
 	line "@@"
 
 _WithExpAllText:: ; 89bd0 (22:5bd0)
-	text "with EXP.SHARE,"
-	cont "@@"
+	text "[PLAYER]'s other"
+        line "#MON gained"
+        cont "EXP. Points from@"
+	db $7
+        text "the EXP.SHARE!"
+        prompt
 
 _BoostedText:: ; 89be1 (22:5be1)
 	text "a boosted"


### PR DESCRIPTION
The previous EXP.SHARE logic first divided the earned
EXP and stat points by two, then distributed experience
to all Pokemon who fought, and then further distributed
experience to all pokemon. This resulted in several
messages that could be annoying to cycle through.
A typical example might look like the following, with
each line requiring a press of the A button:

CHARMANDER gained 100 EXP. Points!
PIDGEY gained 100 EXP. Points!
ABRA gained 100 EXP. Points!
CHARMANDER gained, with EXP.SHARE,
 100 EXP. Points!
PIDGEY gained, with EXP.SHARE,
 100 EXP. Points!
ABRA gained, with EXP.SHARE,
 100 EXP. Points!
PIKACHU gained, with EXP.SHARE,
 100 EXP. Points!
HAUNTER gained, with EXP.SHARE,
 100 EXP. Points!
SLOWPOKE gained, with EXP.SHARE,
 100 EXP. Points!

The message above is fairly typical and requires 15
A-button presses.

The logic has been reworked to first give full
experience to Pokemon who fought in the battle, and
then give half experience to Pokemon who did not fight
in the battle.

The same example now looks like this:

CHARMANDER gained 200 EXP. Points!
PIDGEY gained 200 EXP. Points!
ABRA gained 200 EXP. Points!
PLAYER's other Pokemon gained
 EXP. Points from the EXP.SHARE!
PIKACHU gained 100 EXP. Points!
HAUNTER gained 100 EXP. Points!
SLOWPOKE gained 100 EXP. Points!

This now requires only 8 A-button presses.

Futhermore, boosted EXP from traded Pokemon is now correctly noted.
