### PR TITLE
Fix a bunch of battling glitches native from original red/blue

### DIFF
--- a/engine/battle/5.asm
+++ b/engine/battle/5.asm
@@ -35,8 +35,10 @@ SubstituteEffectHandler: ; 17dad (5:7dad)
 	sbc a, 0      ;borrow from high byte if needed
 	pop bc
 	jr c, .notEnoughHP  ;underflow means user would be left with negative health
-                        ;bug: note since it only brances on carry, it will possibly leave user with 0HP
+
 .userHasZeroOrMoreHP
+	or d
+	jr z, .notEnoughHP ; fail if move would leave user with 0 hp
 	ldi [hl], a  ;store high byte HP
 	ld [hl], d   ;store low byte HP
 	ld h, b

--- a/engine/battle/e_2.asm
+++ b/engine/battle/e_2.asm
@@ -12,11 +12,13 @@ HealEffect_: ; 3b9ec (e:79ec)
 	ld b, a
 	ld a, [de]
 	cp [hl]
+	jr nz, .fine
 	inc de
 	inc hl
 	ld a, [de]
 	sbc [hl]
 	jp z, .failed
+.fine
 	ld a, b
 	cp REST
 	jr nz, .asm_3ba37
@@ -25,15 +27,22 @@ HealEffect_: ; 3b9ec (e:79ec)
 	push af
 	ld c, 50
 	call DelayFrames
-	ld hl, wBattleMonStatus
+	ld bc, wBattleMonStatus
+	ld de, W_PLAYERTOXICCOUNTER
+	ld hl, W_PLAYERBATTSTATUS3
 	ld a, [H_WHOSETURN]
 	and a
 	jr z, .asm_3ba25
-	ld hl, wEnemyMonStatus
+	ld bc, wEnemyMonStatus
+	ld de, W_ENEMYTOXICCOUNTER
+	ld hl, W_ENEMYBATTSTATUS3
 .asm_3ba25
-	ld a, [hl]
+	xor a
+	ld [de], a
+	res 0, [hl]
+	ld a, [bc]
 	and a
-	ld [hl], 2 ; Number of turns from Rest
+	ld [bc], 2 ; Number of turns from Rest
 	ld hl, StartedSleepingEffect
 	jr z, .asm_3ba31
 	ld hl, FellAsleepBecameHealthyText


### PR DESCRIPTION
I fixed:
- Damage is cleared when a pokemon enters the field so counter/bide cannot bounce back damage from non-active pokemon or a previous battle
- Sleep moves ignoring accuracy and working over another status condition if target needs to recharge
- Psywave desync glitch (enemy min damage is now 1)
- Healing moves on 255 or 511 hp
- Permanent invulnerability from dig/fly after full par/confusion
- reflect/light screen stat overflow (made it cap at 1023)
- Rest now gets rid of bad poison
- defense can't become 0 after stat scaling
- bide glitch where the player damage is not fully cleared when enemy faints
- mirror move + partial trapping move desync glitch
- substitute on exactly 25% hp killing user
- an obscure move selection glitch where disable where struggle may not be automatically used when no move is available

Couldn't build because this repo requires an older version of rgbds and i'm lazy, but other than possible random typos everything should be fine.

P.S. sorry for the dirty merge, forgot to sync my repo before working on the new changes.

EDIT: to begin with, I put a ld [bc], 2 in the rest effect because im this cool
